### PR TITLE
Comment and Fix

### DIFF
--- a/load-data.sql
+++ b/load-data.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE IF NOT EXISTS import_gb_csv;
+CREATE DATABASE IF NOT EXISTS import_csv;
 
 -- id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;country;time_zone;is_city;is_main_station;is_airport;is_suggestable;country_hint;main_station_hint;sncf_id;sncf_tvs_id;sncf_is_enabled;entur_id;entur_is_enabled;db_id;db_is_enabled;busbud_id;busbud_is_enabled;distribusion_id;distribusion_is_enabled;flixbus_id;flixbus_is_enabled;cff_id;cff_is_enabled;leoexpress_id;leoexpress_is_enabled;obb_id;obb_is_enabled;ouigo_id;ouigo_is_enabled;trenitalia_id;trenitalia_is_enabled;trenitalia_rtvt_id;trenord_id;ntv_rtiv_id;ntv_id;ntv_is_enabled;hkx_id;hkx_is_enabled;renfe_id;renfe_is_enabled;atoc_id;atoc_is_enabled;benerail_id;benerail_is_enabled;westbahn_id;westbahn_is_enabled;sncf_self_service_machine;same_as;info:de;info:en;info:es;info:fr;info:it;info:nb;info:nl;info:cs;info:da;info:hu;info:ja;info:ko;info:pl;info:pt;info:ru;info:sv;info:tr;info:zh;normalised_code;iata_airport_code
 

--- a/load-data.sql
+++ b/load-data.sql
@@ -2,7 +2,7 @@ CREATE DATABASE IF NOT EXISTS import_csv;
 
 -- id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;country;time_zone;is_city;is_main_station;is_airport;is_suggestable;country_hint;main_station_hint;sncf_id;sncf_tvs_id;sncf_is_enabled;entur_id;entur_is_enabled;db_id;db_is_enabled;busbud_id;busbud_is_enabled;distribusion_id;distribusion_is_enabled;flixbus_id;flixbus_is_enabled;cff_id;cff_is_enabled;leoexpress_id;leoexpress_is_enabled;obb_id;obb_is_enabled;ouigo_id;ouigo_is_enabled;trenitalia_id;trenitalia_is_enabled;trenitalia_rtvt_id;trenord_id;ntv_rtiv_id;ntv_id;ntv_is_enabled;hkx_id;hkx_is_enabled;renfe_id;renfe_is_enabled;atoc_id;atoc_is_enabled;benerail_id;benerail_is_enabled;westbahn_id;westbahn_is_enabled;sncf_self_service_machine;same_as;info:de;info:en;info:es;info:fr;info:it;info:nb;info:nl;info:cs;info:da;info:hu;info:ja;info:ko;info:pl;info:pt;info:ru;info:sv;info:tr;info:zh;normalised_code;iata_airport_code
 
-USE import_gb_csv;
+USE import_csv;
 
 DROP TABLE IF EXISTS stations;
 

--- a/load-data.sql
+++ b/load-data.sql
@@ -1,8 +1,8 @@
-CREATE DATABASE IF NOT EXISTS import_csv;
+CREATE DATABASE IF NOT EXISTS import_gb_csv;
 
 -- id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;country;time_zone;is_city;is_main_station;is_airport;is_suggestable;country_hint;main_station_hint;sncf_id;sncf_tvs_id;sncf_is_enabled;entur_id;entur_is_enabled;db_id;db_is_enabled;busbud_id;busbud_is_enabled;distribusion_id;distribusion_is_enabled;flixbus_id;flixbus_is_enabled;cff_id;cff_is_enabled;leoexpress_id;leoexpress_is_enabled;obb_id;obb_is_enabled;ouigo_id;ouigo_is_enabled;trenitalia_id;trenitalia_is_enabled;trenitalia_rtvt_id;trenord_id;ntv_rtiv_id;ntv_id;ntv_is_enabled;hkx_id;hkx_is_enabled;renfe_id;renfe_is_enabled;atoc_id;atoc_is_enabled;benerail_id;benerail_is_enabled;westbahn_id;westbahn_is_enabled;sncf_self_service_machine;same_as;info:de;info:en;info:es;info:fr;info:it;info:nb;info:nl;info:cs;info:da;info:hu;info:ja;info:ko;info:pl;info:pt;info:ru;info:sv;info:tr;info:zh;normalised_code;iata_airport_code
 
-USE import_csv;
+USE import_gb_csv;
 
 DROP TABLE IF EXISTS stations;
 
@@ -82,14 +82,15 @@ CREATE TABLE stations (
     `info:tr` VARCHAR(50) NULL,
     `info:zh` VARCHAR(50) NULL,
     normalised_code VARCHAR(50) NULL,
-    iata_airport_code CHAR(3) NULL,
-    PRIMARY KEY (id)
+    iata_airport_code CHAR(3) NULL
+#                       ,PRIMARY KEY (id)
 );
 
 LOAD DATA INFILE 'C:\\projects\\load-data-mysql-exercise\\stations.csv'
 INTO TABLE stations
 FIELDS TERMINATED BY ';'
-LINES TERMINATED BY '\r\n'
+# LINES TERMINATED BY '\\r\\n' -- separatore per CRLF
+LINES TERMINATED BY '\\n' -- separatore per LF
 IGNORE 1 LINES
 (
     id, 
@@ -167,9 +168,9 @@ IGNORE 1 LINES
     `info:tr`,
     `info:zh`,
     normalised_code,
-    @iata_airport_code
-)
-SET iata_airport_code = NULLIF( IFNULL(@iata_airport_code, ''),'' );
+    iata_airport_code
+);
+# SET iata_airport_code = NULLIF( IFNULL(@iata_airport_code, ''),'' );
 
 SELECT id,name, `info:it`, iata_airport_code, normalised_code
 FROM stations


### PR DESCRIPTION
## Problema del Caricamento Dati con `LOAD DATA INFILE` da CSV

### Contesto
Stai utilizzando il comando `LOAD DATA INFILE` per caricare dati da file CSV in una tabella MySQL. Hai notato differenze nel comportamento basato sulla formattazione delle linee dei file CSV:

1. **File Formattato in LF**:
   - Utilizza `\n` (LF) come separatore di linea.
   - Funziona senza specificare `LINES TERMINATED BY`.

2. **File Convertito in CRLF (tramite IDE)**:
   - Convertito dall'IDE per usare `\r\n` (CRLF).
   - Funziona senza specificare `LINES TERMINATED BY`, se l'IDE non cambia il contenuto binario del file, ma solo la rappresentazione.

3. **File "nato" in CRLF**:
   - Creato originariamente con `\r\n` (CRLF) come separatore di linea.
   - Richiede esplicitamente `LINES TERMINATED BY '\\r\\n'` per essere caricato correttamente.

---

## Soluzioni

### 1. Specifica Esplicita di `LINES TERMINATED BY`
Indipendentemente dal tipo di separatore di linea, specifica sempre `LINES TERMINATED BY` per garantire che MySQL interpreti correttamente i fine riga.

```sql
LOAD DATA INFILE 'C:\\path\\to\\your\\file.csv'
INTO TABLE your_table
FIELDS TERMINATED BY ';'
LINES TERMINATED BY '\\r\\n'
```

### 2. Uniformazione della Formattazione
Converti tutti i tuoi file al delimitatore di linea LF (`\n`) per evitare problemi di compatibilità. Utilizza strumenti o funzionalità di conversione del tuo IDE )oppure notepad++, perchè alcuni IDE potrebbero non essere in grado di operare su file di grosse dimensioni).

---

## Esempio di Comando Generale

Usare `LINES TERMINATED BY '\\r\\n'` che copre il caso più complesso:

```sql
LOAD DATA INFILE 'C:\\path\\to\\your\\file.csv'
INTO TABLE your_table
FIELDS TERMINATED BY ';'
LINES TERMINATED BY '\\r\\n'
```

---

## Conclusione
Specificare esplicitamente `LINES TERMINATED BY` e uniformare la formattazione delle linee dei file CSV ti permette di evitare problemi durante il caricamento dei dati in MySQL.